### PR TITLE
code coverage support

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -207,7 +207,7 @@ var printStderr = function(stderr) {
   }
 };
 
-var printTestsSummary = function(dateStart, successes, failures, timeouts) {
+var printTestsSummary = function(dateStart, successes, failures, timeouts, coverage) {
   var dateEnd = testUtil.getUnixTimestamp();
   var runTime = (dateEnd - dateStart);
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -207,7 +207,7 @@ var printStderr = function(stderr) {
   }
 };
 
-var printTestsSummary = function(dateStart, successes, failures, timeouts, coverage) {
+var printTestsSummary = function(dateStart, successes, failures, timeouts) {
   var dateEnd = testUtil.getUnixTimestamp();
   var runTime = (dateEnd - dateStart);
 

--- a/lib/extern/optparse/lib/optparse.js
+++ b/lib/extern/optparse/lib/optparse.js
@@ -292,8 +292,11 @@ OptionParser.prototype = {
             var text; 
             rule = rules[i];
             if(shorts) {
-                if(rule.short) text = spaces(2) + rule.short + ', ';
-                else text = spaces(6);
+                if(rule.short) {
+                  text = spaces(2) + rule.short + ', ';
+                } else {
+                  text = spaces(6);
+                }
             }
             text += spaces(rule.decl, longest) + spaces(3);
             text += rule.desc;

--- a/lib/run.js
+++ b/lib/run.js
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-process.chdir(__dirname);
-
 var fs = require('fs');
 var sys = require('sys');
 var path = require('path');
@@ -30,11 +28,15 @@ var parser = require('./parser');
 var common = require('./common');
 var testUtil = require('./util');
 
+var childProcess = require('child_process');
+
 var successes = 0;
 var failures = 0;
 var timeouts = 0;
 
 var dateStart;
+
+var coverage = {};
 
 /**
  * Spawn a new child, run a test file and report results.
@@ -60,7 +62,7 @@ var executeTest = function(cwd, chdir, testInitFile, filePath, failfast, timeout
 
   testUtil.printMsg(sprintf('Running test file: %s', fileName), verbosity, 3);
 
-  var args = ['run_test_file.js', filePath, cwd, chdir, testInitFile, functionsTimeout];
+  var args = ['--cov', path.join(__dirname, 'run_test_file.js'), filePath, cwd, testInitFile, functionsTimeout];
   var child = spawn(process.execPath, args);
   var stderr = [];
   var stdout = [];
@@ -117,8 +119,10 @@ var executeTest = function(cwd, chdir, testInitFile, filePath, failfast, timeout
       }
     }
 
+    coverage[fileName] = JSON.parse(fs.readFileSync(path.join(cwd, 'node-cov.json')));
+
     if (failfast && failedResult) {
-      common.printTestsSummary(dateStart, successes, failures, timeouts);
+      common.printTestsSummary(dateStart, successes, failures, timeouts, coverage);
     }
 
     callback(null);
@@ -146,7 +150,7 @@ var runTests = function(cwd, initFile, testInitFile, chdir, tests, failFast,
     },
 
     function(err) {
-      common.printTestsSummary(dateStart, successes, failures, timeouts);
+      common.printTestsSummary(dateStart, successes, failures, timeouts, coverage);
     });
   };
 
@@ -164,7 +168,7 @@ var runTests = function(cwd, initFile, testInitFile, chdir, tests, failFast,
 };
 
 process.addListener('SIGINT', function() {
-  common.printTestsSummary(dateStart, successes, failures, timeouts);
+  common.printTestsSummary(dateStart, successes, failures, timeouts, coverage);
 });
 
 var run = function(cwd, argv) {
@@ -245,6 +249,7 @@ var run = function(cwd, argv) {
   else {
     sys.puts(p.banner);
   }
+
 };
 
 exports.run = run;

--- a/lib/run.js
+++ b/lib/run.js
@@ -36,8 +36,6 @@ var timeouts = 0;
 
 var dateStart;
 
-var coverage = {};
-
 /**
  * Spawn a new child, run a test file and report results.
  *
@@ -124,11 +122,32 @@ var executeTest = function(cwd, chdir, testInitFile, filePath, failfast, timeout
     }
 
     try {
-      coverage[fileName] = JSON.parse(fs.readFileSync(path.join(cwd, 'node-cov.json')));
+      var coverage = JSON.parse(fs.readFileSync(path.join(cwd, 'node-cov.json')));
+          source = fs.readFileSync(filePath, 'utf8'),
+          lines = source.split('\n'),
+          out = '<html><style>pre { margin: 0; padding: 0; } </style><body>';
+
+      out += '<h2>' + path.basename(filePath) + '</h2><div>';
+
+      var stats = coverage[path.join(__dirname, 'run_test_file.js')];
+      for (var i = 0; i < lines.length; i++) {
+        lines[i] = lines[i].replace('<', '&lt;');
+        lines[i] = lines[i].replace('>', '&gt;');
+        if (stats.hasOwnProperty(i) && stats[i]) {
+          out += '<pre>'
+        } else {
+          out += '<pre style="background: #faa">'
+        }
+        out += lines[i] + '</pre>\n';
+      }
+
+      out += "</div></html>";
+
+      fs.writeFileSync(filePath.replace('.js', '.html'), out);
     } catch (e) { }
 
     if (failfast && failedResult) {
-      common.printTestsSummary(dateStart, successes, failures, timeouts, coverage);
+      common.printTestsSummary(dateStart, successes, failures, timeouts);
     }
 
     callback(null);
@@ -156,7 +175,7 @@ var runTests = function(cwd, initFile, testInitFile, chdir, tests, failFast,
     },
 
     function(err) {
-      common.printTestsSummary(dateStart, successes, failures, timeouts, coverage);
+      common.printTestsSummary(dateStart, successes, failures, timeouts);
     });
   };
 
@@ -174,7 +193,7 @@ var runTests = function(cwd, initFile, testInitFile, chdir, tests, failFast,
 };
 
 process.addListener('SIGINT', function() {
-  common.printTestsSummary(dateStart, successes, failures, timeouts, coverage);
+  common.printTestsSummary(dateStart, successes, failures, timeouts);
 });
 
 var run = function(cwd, argv) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -62,7 +62,11 @@ var executeTest = function(cwd, chdir, testInitFile, filePath, failfast, timeout
 
   testUtil.printMsg(sprintf('Running test file: %s', fileName), verbosity, 3);
 
-  var args = ['--cov', path.join(__dirname, 'run_test_file.js'), filePath, cwd, testInitFile, functionsTimeout];
+  var version = process.version.split('.');
+  var args = [path.join(__dirname, 'run_test_file.js'), filePath, cwd, testInitFile, functionsTimeout];
+  if (version[1] >= 5) {
+    args.unshift('--cov');
+  }
   var child = spawn(process.execPath, args);
   var stderr = [];
   var stdout = [];
@@ -119,7 +123,9 @@ var executeTest = function(cwd, chdir, testInitFile, filePath, failfast, timeout
       }
     }
 
-    coverage[fileName] = JSON.parse(fs.readFileSync(path.join(cwd, 'node-cov.json')));
+    try {
+      coverage[fileName] = JSON.parse(fs.readFileSync(path.join(cwd, 'node-cov.json')));
+    } catch (e) { }
 
     if (failfast && failedResult) {
       common.printTestsSummary(dateStart, successes, failures, timeouts, coverage);

--- a/lib/run_test_file.js
+++ b/lib/run_test_file.js
@@ -42,18 +42,13 @@ process.nextTick(function() {
   var paths_to_require = [];
   var testPath = process.argv[2];
   var cwd = (process.argv.length >= 4) ? process.argv[3] : null;
-  var chdir = (process.argv.length >= 5) ? process.argv[4] : null;
-  var testInitFile = (process.argv.length >= 6) ? process.argv[5] : null;
-  var timeout = (process.argv.length === 7) ? parseInt(process.argv[6], 10) : null;
+  var testInitFile = (process.argv.length >= 6) ? process.argv[4] : null;
+  var timeout = (process.argv.length === 7) ? parseInt(process.argv[5], 10) : null;
   var testModule = testPath.replace(/\.js$/, '');
 
   testUtil.addToRequirePaths(testPath, cwd);
 
   var exportedFunctions, errName;
-
-  if (!testUtil.isNull(chdir)) {
-    testUtil.callIgnoringError(process.chdir, null, [chdir]);
-  }
 
   try {
     exportedFunctions = require(testModule);


### PR DESCRIPTION
Propagate a map of files and their code coverage results to the print function.

Tested with: node[master]. 
