### PR TITLE
make the testObj a function

### DIFF
--- a/example/test-success.js
+++ b/example/test-success.js
@@ -26,9 +26,9 @@ exports['test_true_equals_true'] = function(test, assert) {
   }, 100);
 };
 
-exports['test_two_plus_two_equals_four'] = function(test, assert) {
+exports['test_two_plus_two_equals_four'] = function(done, assert) {
   assert.equal(2 + 2, 4);
-  test.finish();
+  done();
 };
 
 exports['tearDown'] = function(test, assert) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -113,9 +113,10 @@ Test.prototype.run = function(callback) {
 };
 
 Test.prototype._getTestObject = function(finishFunc) {
-  var testObj = {
-    'finish': finishFunc
-  };
+  var testObj = function test() {
+    return finishFunc.apply(undefined, arguments)
+  }
+  testObj.finish = finishFunc
 
   return testObj;
 };


### PR DESCRIPTION
This makes it easier to write simple tests, as you can just call the testObj as a function to finish. All arguments are forwarded on, and `.finish` is attached so it should be backwards (and forwards) compatible.

Example:

```
exports['test_example'] = function(done, assert) {
  done()
}
```

Calling `test.finish` is also still supported:

```
exports['test_example'] = function(test, assert) {
  test.finish()
}
```
