### PR TITLE
output the actual given test file path instead of just the basename

### DIFF
--- a/lib/reporters/test/cli.js
+++ b/lib/reporters/test/cli.js
@@ -39,9 +39,8 @@ CliReporter.prototype.handleTestsStart = function() {
   this._dateStart = testUtil.getUnixTimestamp();
 };
 
-CliReporter.prototype.handleTestFileStart = function(filePath) {
-  var fileName = path.basename(filePath);
-  console.log(fileName);
+CliReporter.prototype.handleTestFileStart = function(filePath, filePathArg) {
+  console.log(filePathArg);
 };
 
 CliReporter.prototype.handleTestFileComplete = function(filePath, stdout, stderr) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -123,8 +123,9 @@ TestRunner.prototype.runTests = function(testInitFile, chdir,
       }
 
       cwd = process.cwd();
+      var filePathArg = filePath;
       filePath = (filePath.charAt(0) !== '/') ? path.join(cwd, filePath) : filePath;
-      child = self._spawnTestProcess(filePath, testInitFile, chdir,
+      child = self._spawnTestProcess(filePath, filePathArg, testInitFile, chdir,
                                      customAssertModule, timeout,
                                      concurrency);
       timeoutId = setTimeout(function() {
@@ -166,6 +167,7 @@ TestRunner.prototype.runTests = function(testInitFile, chdir,
 };
 
 TestRunner.prototype._spawnTestProcess = function(filePath,
+                                                  filePathArg,
                                                   testInitFile,
                                                   chdir,
                                                   customAssertModule,
@@ -178,7 +180,7 @@ TestRunner.prototype._spawnTestProcess = function(filePath,
               this._scopeLeaks, chdir, customAssertModule, testInitFile,
               timeout, concurrency];
 
-  this._testReporter.handleTestFileStart(filePath);
+  this._testReporter.handleTestFileStart(filePath, filePathArg);
   var child = spawn(process.execPath, args);
   return child;
 };


### PR DESCRIPTION
This can help: when the set of test files might include 2 with the same
basename; for using the test output to cut 'n paste in the test file
to open.
