### PR TITLE
fix `assert.eql` (it was being assigned a value that didn't exist yet)

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -59,7 +59,7 @@ var assert = {};
   /*
    * Alias deepEqual as eql for complex equality
    */
-  assert.eql = assert.deepEqual;
+  assert.eql = origAssert.deepEqual;
 
   /**
    * Assert that `val` is null.


### PR DESCRIPTION
We need to use origAssert when assigning to assert.eql as the original methods have not been merged into the custom assert module yet.
