### PR TITLE
Process runner doesn't error correctly when jobs fail.

### DIFF
--- a/lib/process_runner/run.js
+++ b/lib/process_runner/run.js
@@ -59,6 +59,7 @@ function run(argv) {
       if (err) {
         term.puts('Failed to start processes!');
         term.puts(sprintf('Error: %s', err.message));
+        process.exit(1);
       }
       else {
         term.puts('All processes started');

--- a/lib/process_runner/runner.js
+++ b/lib/process_runner/runner.js
@@ -251,7 +251,12 @@ ProcessRunner.prototype.start = function(names, callback) {
 
   async.auto(ops, function(err) {
     if (err) {
-      self.stop(callback);
+      self.stop(function(err2) {
+        if (err2) {
+          callback(err2);
+        }
+        callback(err);
+      });
       return;
     }
 


### PR DESCRIPTION
As I found out, if a process takes too long to start up, whiskey won't generate useful error messages.
