### PR TITLE
Make with an alias for withArgs as with is a reserved word in JavaScript

### DIFF
--- a/example/test-spyon.js
+++ b/example/test-spyon.js
@@ -85,6 +85,17 @@ exports['test_spyon_with_arguments_correct'] = function(test, assert) {
   arr = ['a', 'b', null];
   test.spy.on('setBar', foo);
   foo.setBar(arr);
+  assert.ok(test.spy.called('setBar').withArgs(arr));
+  test.spy.clear('setBar', foo);
+  test.finish();
+};
+
+exports['test_spyon_with_arguments_alias'] = function(test, assert) {
+  var foo, arr;
+  foo = new Foo();
+  arr = ['a', 'b', null];
+  test.spy.on('setBar', foo);
+  foo.setBar(arr);
   assert.ok(test.spy.called('setBar').with(arr));
   test.spy.clear('setBar', foo);
   test.finish();
@@ -96,7 +107,7 @@ exports['test_spyon_with_arguments_incorrect'] = function(test, assert) {
   arr = ['a', 'b', null];
   test.spy.on('setBar', foo);
   foo.setBar(['c']);
-  assert.ok(!test.spy.called('setBar').with(arr));
+  assert.ok(!test.spy.called('setBar').withArgs(arr));
   test.spy.clear('setBar', foo);
   test.finish();
 };

--- a/lib/common.js
+++ b/lib/common.js
@@ -639,7 +639,7 @@ SpyOn.prototype.called = function (funcName) {
     valueOf: function () {
       return calls.length;
     },
-    with: function () {
+    withArgs: function () {
       var i, j, match;
       var args = Array.prototype.slice.call(arguments);
       for (i = 0; i < calls.length; i++) {
@@ -648,6 +648,9 @@ SpyOn.prototype.called = function (funcName) {
         }
       }
       return false;
+    },
+    with: function () {
+      return this.withArgs.apply(this, arguments);
     }
   }
 };


### PR DESCRIPTION
For tests I simply copied one of the withArgs test and replaced with with but maybe the better thing is to check that with calls withArgs, but there's not a lot of meta testing in the spy code.
