### PR TITLE
GTG: Add rewire to work with istanbul for coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CWD=`pwd`
 
 test:
-	NODE_PATH=lib-cov ${CWD}/test/run.sh
+	${CWD}/test/run.sh
 
 example:
 	${CWD}/bin/whiskey --tests "${CWD}/example/test-success.js ${CWD}/example/test-failure.js"

--- a/example/test-coverage.js
+++ b/example/test-coverage.js
@@ -7,7 +7,7 @@ var sprintf = require('sprintf').sprintf;
 
 var cwd = process.cwd();
 
-exec(sprintf('NODE_PATH=lib-cov %s/bin/whiskey --tests %s/example/test-success-with-coverage.js --timeout 6000 --coverage --coverage-reporter cli', cwd, cwd),
+exec(sprintf('%s/bin/whiskey --tests %s/example/test-success-with-coverage.js --timeout 6000 --coverage --coverage-reporter cli', cwd, cwd),
   function(err, stdout, stderr) {
     try {
       assert.match(stdout, /test coverage/i);

--- a/example/test-success-with-coverage.js
+++ b/example/test-success-with-coverage.js
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
+var coverage = require('../lib/coverage');
+
 exports['test_coverage_file_coverage'] = function(test, assert) {
-  require('coverage');
   assert.ok(true);
   test.finish();
 };

--- a/lib/common.js
+++ b/lib/common.js
@@ -16,6 +16,7 @@
  *
  */
 
+var fs = require('fs');
 var path = require('path');
 var net = require('net');
 var util = require('util');
@@ -25,6 +26,9 @@ var async = require('async');
 var gex = require('gex');
 var underscore = require('underscore');
 var log = require('logmagic').local('whiskey.common');
+
+var requiredAs = require('required-as');
+var rewire = require('rewire');
 
 var assert = require('./assert');
 var constants = require('./constants');
@@ -285,6 +289,7 @@ function TestFile(filePath, options, chdir) {
   this._timeout = options['timeout'];
   this._concurrency = options['concurrency'];
   this._scopeLeaks = options['scope_leaks'];
+  this._covered = options.covered;
 
   this._tests = [];
   this._uncaughtExceptions = [];
@@ -352,7 +357,37 @@ TestFile.prototype.runTests = function(callback) {
     function(callback) {
       var errName;
       try {
-        exportedFunctions = require(testModule);
+        if (self._covered) {
+          // If coverage is request, we want the testModule to reference the
+          // code instrumented by istanbul in lib-cov/ instead of any local code in lib/.
+          // This passage looks for variables assigned to by require('lib/*')
+          // and sets a value for the variable which is the equivalent module in lib-cov.
+
+          var fullModuleName = path.resolve(testModule);
+          if (!fullModuleName.match(/\.js$/)) {
+            fullModuleName = fullModuleName + '.js';
+          }
+          var requirements = requiredAs(fullModuleName);
+
+          // for every requirement in lib/, rewrite to lib-cov/
+          var newRequirements = underscore.map(requirements, function(req) {
+            if (req.source.match(/node_modules/) || !req.source.match(/lib\//)) {
+              return undefined;
+            }
+            req.source = path.resolve(path.dirname(fullModuleName), req.source);
+            req.source = req.source.replace(/lib\//, 'lib-cov/');
+
+            return req;
+          });
+
+          exportedFunctions = rewire(fullModuleName);
+
+          underscore.each(newRequirements.filter(function(i) { return i; }), function(nr) {
+            exportedFunctions.__set__(nr.name, require(nr.source));
+          });
+        } else {
+          exportedFunctions = require(testModule);
+        }
       }
       catch (err) {
         if (err.message.indexOf(testModule) !== -1 &&

--- a/lib/run.js
+++ b/lib/run.js
@@ -481,7 +481,7 @@ function run(cwd, argv) {
   var runner, testReporter, coverageArgs;
   var socketPath, concurrency, scopeLeaks, runnerArgs;
   var intersection;
-  var chdir, ms, nodePath, istanbulBinary;
+  var chdir, ms, istanbulBinary;
 
   if ((argv === undefined) && (cwd instanceof Array)) {
     argv = cwd;
@@ -590,12 +590,6 @@ function run(cwd, argv) {
 
 
     if (options['coverage']) {
-      nodePath = process.env['NODE_PATH'];
-
-      if (!nodePath || nodePath.indexOf('lib-cov') === -1) {
-        throw new Error('lib-cov is not in NODE_PATH. NODE_PATH environment variable' +
-                         ' must contain lib-cov path for the coverage to work.');
-      }
 
       istanbulBinary = path.resolve(__dirname, '../node_modules/.bin/istanbul');
       coverageArgs = [istanbulBinary, 'instrument', '--no-compact', '--complete-copy'];

--- a/lib/run_test_file.js
+++ b/lib/run_test_file.js
@@ -73,6 +73,7 @@ var testPath = args['test_path'];
 var socketPath = args['socket_path'];
 var cwd = args['cwd'];
 var libCovDir = args['lib_cov_dir'];
+var covered = !!libCovDir; // hack
 var scopeLeaks = args['scope_leaks'];
 var chdir = args['chdir'];
 var customAssertModule = args['custom_assert_module'];
@@ -93,6 +94,7 @@ if (chdir && path.existsSync(chdir)) {
 var options = { 'cwd': cwd, 'socket_path': socketPath,
                 'init_file': testInitFile, 'timeout': timeout,
                 'concurrency': concurrency, 'scope_leaks': scopeLeaks,
+                'covered': covered,
                 'pattern': pattern};
 var testFile = new common.TestFile(testPath, options, chdir);
 testFile.runTests(function onTestFileEnd() {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "simplesets": "= 1.1.6",
     "logmagic": "= 0.1.4",
     "underscore": ">= 1.4.2",
-    "istanbul": ">= 0.1.37"
+    "istanbul": ">= 0.1.37",
+    "rewire": ">= 1.1.3",
+    "required-as": ">= 0.0.0"
   },
   "devDependencies": {
     "jshint": "2.1.3"


### PR DESCRIPTION
Add rewire to TestFile.runTests() so when coverage is running, the test module has the covered resources in lib/ injected into its scope.
