### PR TITLE
Propegates exceptions from child to parent process.

### DIFF
--- a/bin/whiskey
+++ b/bin/whiskey
@@ -36,6 +36,7 @@ logmagic.route('whiskey.process_runner.*', logmagic.INFO, 'process_runner');
 whiskey.run(cwd, argv);
 
 process.on('uncaughtException', function(err) {
+  console.log("** UNCAUGHT EXCEPTION IN PARENT PROCESS **");
   console.log(err.message);
 
   if (err.stack) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -306,7 +306,7 @@ TestFile.prototype.getConnection = function(callback) {
     self._connection = connection;
     callback();
   });
-}
+};
 
 TestFile.prototype.runTests = function(callback) {
   var self = this;
@@ -498,7 +498,7 @@ TestFile.prototype._reportException = function(exc) {
     JSON.stringify(exc),
     constants.EXCEPTION_END_MARKER);
   this._connection.write(payload);
-}
+};
 
 TestFile.prototype._reportTestResult = function(resultObj) {
   var payload;

--- a/lib/common.js
+++ b/lib/common.js
@@ -302,7 +302,7 @@ TestFile.prototype.getConnection = function(callback) {
     return;
   }
   callback();
-}
+};
 
 TestFile.prototype._setConnection = function(callback) {
   var self = this;

--- a/lib/common.js
+++ b/lib/common.js
@@ -135,13 +135,11 @@ function errorFromObj(actualErr) {
     err = actualErr;
   }
   else if (underscore.isString(actualErr)) {
-    err = {}
-    err.message = actualErr;
+    err = new Error(actualErr);
   }
   else if (!actualErr.hasOwnProperty('message') && actualErr.toString &&
            typeof actualErr.toString === 'function') {
-    err = {};
-    err.message = actualErr.toString();
+    err = new Error(actualErr.toString());
   }
   else {
     err = actualErr;

--- a/lib/common.js
+++ b/lib/common.js
@@ -297,6 +297,14 @@ TestFile.prototype.addTest = function(test) {
 };
 
 TestFile.prototype.getConnection = function(callback) {
+  if (!this._connection) {
+    this._setConnection(callback);
+    return;
+  }
+  callback();
+}
+
+TestFile.prototype._setConnection = function(callback) {
   var self = this;
   this._getConnection(function(err, connection) {
     if (err) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -128,6 +128,28 @@ Test.prototype._getLeakedVariables = function(scopeBefore, scopeAfter) {
   return scopeleaks.getDifferences(scopeBefore, scopeAfter);
 };
 
+function errorFromObj(actualErr) {
+  var err;
+
+  if (actualErr instanceof Error) {
+    err = actualErr;
+  }
+  else if (underscore.isString(actualErr)) {
+    err = {}
+    err.message = actualErr;
+  }
+  else if (!actualErr.hasOwnProperty('message') && actualErr.toString &&
+           typeof actualErr.toString === 'function') {
+    err = {};
+    err.message = actualErr.toString();
+  }
+  else {
+    err = actualErr;
+  }
+
+  return err;
+}
+
 Test.prototype.run = function(callback) {
   var self = this;
   var scopeBefore, scopeAfter, err;
@@ -169,22 +191,7 @@ Test.prototype.run = function(callback) {
 
   }
   catch (actualErr) {
-    if ((actualErr instanceof Error)) {
-      err = actualErr;
-    }
-    else if (underscore.isString(actualErr)) {
-      err = {};
-      err.message = actualErr;
-    }
-    else if (!actualErr.hasOwnProperty('message') && actualErr.toString &&
-             typeof actualErr.toString === 'function') {
-       err = {};
-       err.message = actualErr.toString();
-    }
-    else {
-      err = actualErr;
-    }
-
+    err = errorFromObj(actualErr);
     scopeAfter = this._getScopeSnapshot(global);
     this._leakedVariables = this._getLeakedVariables(scopeBefore, scopeAfter);
 
@@ -499,7 +506,7 @@ TestFile.prototype._getConnection = function(callback) {
 
 TestFile.prototype._reportException = function(exc) {
   var payload;
-  exc.message = exc.message || 'Message field not set in exception object';
+  exc = errorFromObj(exc);
   payload = sprintf('%s%s%s%s\n',
     exc.message,
     constants.DELIMITER,

--- a/lib/common.js
+++ b/lib/common.js
@@ -296,6 +296,18 @@ TestFile.prototype.addTest = function(test) {
   this._tests.push(test);
 };
 
+TestFile.prototype.getConnection = function(callback) {
+  var self = this;
+  this._getConnection(function(err, connection) {
+    if (err) {
+      callback(new Error('Unable to establish connection with the master process'));
+      return;
+    }
+    self._connection = connection;
+    callback();
+  });
+}
+
 TestFile.prototype.runTests = function(callback) {
   var self = this;
   var i, test, exportedFunctions, exportedFunctionsNames, errName;
@@ -324,20 +336,6 @@ TestFile.prototype.runTests = function(callback) {
   }
 
   async.series([
-    // Obtain the connection
-    function(callback) {
-      self._getConnection(function(err, connection) {
-        if (err) {
-          callback(new Error('Unable to establish connection with the master ' +
-                             'process'));
-          return;
-        }
-
-        self._connection = connection;
-        callback();
-      });
-    },
-
     // if test init file is present, run init function in it
     function(callback) {
       if (!self._testInitFile) {
@@ -490,6 +488,17 @@ TestFile.prototype._getConnection = function(callback) {
     callback(err, null);
   });
 };
+
+TestFile.prototype._reportException = function(exc) {
+  var payload;
+  exc.message = exc.message || 'Message field not set in exception object';
+  payload = sprintf('%s%s%s%s\n',
+    exc.message,
+    constants.DELIMITER,
+    JSON.stringify(exc),
+    constants.EXCEPTION_END_MARKER);
+  this._connection.write(payload);
+}
 
 TestFile.prototype._reportTestResult = function(resultObj) {
   var payload;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -66,6 +66,7 @@ var DELIMITER = '@-delimiter-@';
 var TEST_END_MARKER = '@-end-test-@';
 var TEST_FILE_END_MARKER = '@-end-test-file-@';
 var COVERAGE_END_MARKER = '@-end-coverage-@';
+var EXCEPTION_END_MARKER = '@-end-exception-@';
 
 /**
  * Default switches for the option parser.
@@ -162,3 +163,4 @@ exports.DELIMITER = DELIMITER;
 exports.TEST_END_MARKER = TEST_END_MARKER;
 exports.TEST_FILE_END_MARKER = TEST_FILE_END_MARKER;
 exports.COVERAGE_END_MARKER = COVERAGE_END_MARKER;
+exports.EXCEPTION_END_MARKER = EXCEPTION_END_MARKER;

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -208,7 +208,6 @@ function populateCoverage(results, cov) {
   /* Calculate covergage of tests */
   results.coverage = (results.totalHits / results.SLOC) * 100;
   results.coverage = results.coverage.toFixed(2);
-
   return results;
 }
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -420,9 +420,21 @@ TestRunner.prototype._handleConnection = function(connection) {
   var dataString, endMarkIndex, testFile, testFileCallback, testFileTimeoutId;
 
   function onLine(line) {
-    var result, filePath, end, resultObj;
+    var result, filePath, end, resultObj, msg, jsonPayload;
     result = testUtil.parseResultLine(line);
     end = result[0];
+    if (typeof end === 'string') {
+      // Uncaught exception was thrown in the child process, but which did
+      // not originate from within any test.  This is a critical error implying
+      // a bug from within Whiskey itself, often as a result of new features
+      // added or other bug fixes.  As devs, we need to know of these errors right
+      // away.
+      jsonPayload = JSON.stringify(JSON.parse(result[1]), null, 2);
+      msg = sprintf("** EXCEPTION CAUGHT IN CHILD PROCESS **\n\n%s\n\n%s", end, jsonPayload);
+      throw {
+        message: msg
+      };
+    }
     filePath = result[1];
     resultObj = result[2];
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -423,7 +423,7 @@ TestRunner.prototype._handleConnection = function(connection) {
     var result, filePath, end, resultObj, msg, jsonPayload;
     result = testUtil.parseResultLine(line);
     end = result[0];
-    if (typeof end === 'string') {
+    if (underscore.isString(end)) {
       // Uncaught exception was thrown in the child process, but which did
       // not originate from within any test.  This is a critical error implying
       // a bug from within Whiskey itself, often as a result of new features

--- a/lib/run.js
+++ b/lib/run.js
@@ -417,47 +417,18 @@ TestRunner.prototype._handleConnection = function(connection) {
   var self = this;
   var data = '';
   var lineProcessor = new testUtil.LineProcessor();
-  var dataString, endMarkIndex, testFile, testFileCallback, testFileTimeoutId;
 
-  function onLine(line) {
+  lineProcessor.on('line', function(line) {
     var result, filePath, end, resultObj, msg, jsonPayload;
-    result = testUtil.parseResultLine(line);
-    end = result[0];
-    if (underscore.isString(end)) {
-      // Uncaught exception was thrown in the child process, but which did
-      // not originate from within any test.  This is a critical error implying
-      // a bug from within Whiskey itself, often as a result of new features
-      // added or other bug fixes.  As devs, we need to know of these errors right
-      // away.
-      jsonPayload = JSON.stringify(JSON.parse(result[1]), null, 2);
-      msg = sprintf("** EXCEPTION CAUGHT IN CHILD PROCESS **\n\n%s\n\n%s", end, jsonPayload);
-      throw {
-        message: msg
-      };
-    }
-    filePath = result[1];
-    resultObj = result[2];
+    result = testUtil.parseResultLine(line, self);
+    result.throwPendingExceptions();
+    result.handleResult();
+  });
 
-    if (end) {
-      return;
-    }
-
-    if (resultObj.hasOwnProperty('coverage')) {
-      self._handleTestCoverageResult(filePath, resultObj['coverage']);
-    }
-    else {
-      self._handleTestResult(filePath, resultObj);
-    }
-  }
-
-  lineProcessor.on('line', onLine);
-
-  function onData(chunk) {
-    lineProcessor.appendData(chunk);
-    data += chunk;
-  }
-
-  connection.on('data', onData);
+  connection.on('data', function(chunk) {
+        lineProcessor.appendData(chunk);
+        data += chunk;
+  });
 };
 
 TestRunner.prototype._startServer = function(connectionHandler,

--- a/lib/run_test_file.js
+++ b/lib/run_test_file.js
@@ -113,7 +113,7 @@ testFile.getConnection(function(err) {
       testFile.addUncaughtException(err);
     });
   }
-  catch (err) {
-    testFile._reportException(err);
+  catch (exc) {
+    testFile._reportException(exc);
   }
 });

--- a/lib/run_test_file.js
+++ b/lib/run_test_file.js
@@ -95,13 +95,25 @@ var options = { 'cwd': cwd, 'socket_path': socketPath,
                 'concurrency': concurrency, 'scope_leaks': scopeLeaks,
                 'pattern': pattern};
 var testFile = new common.TestFile(testPath, options, chdir);
-testFile.runTests(function onTestFileEnd() {
-  if (libCovDir && typeof __coverage__ === 'object') {
-    testFile._reportTestCoverage(__coverage__);
+testFile.getConnection(function(err) {
+  if (err) {
+    testFile._reportException(err);
+    return;
   }
-  testFile._reportTestFileEnd();
-});
 
-process.on('uncaughtException', function(err) {
-  testFile.addUncaughtException(err);
+  try {
+    testFile.runTests(function onTestFileEnd() {
+      if (libCovDir && typeof __coverage__ === 'object') {
+        testFile._reportTestCoverage(__coverage__);
+      }
+      testFile._reportTestFileEnd();
+    });
+
+    process.on('uncaughtException', function(err) {
+      testFile.addUncaughtException(err);
+    });
+  }
+  catch (err) {
+    testFile._reportException(err);
+  }
 });

--- a/lib/util.js
+++ b/lib/util.js
@@ -161,11 +161,66 @@ LineProcessor.prototype._processData = function() {
   }
 };
 
-function parseResultLine(line) {
-  // Returns a triple (end, fileName, resultObj)
+function EndMarker() {
+  this.handleResult = function() {
+    // does nothing; end of input has no results to handle.
+  };
+
+  this.throwPendingExceptions = function() {
+    // does nothing; end of input has no exceptions to handle.
+  };
+};
+
+function ExceptionMarker(err) {
+  this._err = err;
+
+  this.handleResult = function() {
+    // does nothing; exceptions aren't tests.
+  };
+
+  this.throwPendingExceptions = function() {
+    throw this._err;
+  };
+};
+
+function CoverageMarker(testRunner, filePath, coverage) {
+  this._runner = testRunner;
+  this._filePath = filePath;
+  this._coverage = coverage;
+
+  this.handleResult = function() {
+    this._runner._handleTestCoverageResult(this._filePath, this._coverage);
+  };
+
+  this.throwPendingExceptions = function() {
+    // No exceptions exist for test results.
+  };
+};
+
+function TestResultMarker(testRunner, filePath, resultObj) {
+  this._runner = testRunner;
+  this._filePath = filePath;
+  this._results = resultObj;
+
+  this.handleResult = function() {
+    this._runner._handleTestResult(this._filePath, this._results);
+  };
+
+  this.throwPendingExceptions = function() {
+    // No exceptions exist for test results.
+  };
+};
+
+function parseResultLine(line, runner) {
+  // Returns one of {TestResultMarker, CoverageMarker,
+  // ExceptionMarker, or EndMarker} instances.  In each
+  // case, the object methods handleResult() and
+  // throwPendingExceptions() behave appropriately for the
+  // specific case represented by the marker object.
+
   var startMarkerIndex, endMarkerIndex, testFileEndMarkerIndex, exceptionIndex;
   var coverageEndMarker, split, fileName, resultObj;
-  var exceptionString, exceptionObj;
+  var exceptionString, exceptionObj, exceptionJsons, msg;
 
   testFileEndMarkerIndex = line.indexOf(constants.TEST_FILE_END_MARKER);
   coverageEndMarker = line.indexOf(constants.COVERAGE_END_MARKER);
@@ -174,32 +229,30 @@ function parseResultLine(line) {
   exceptionIndex = line.indexOf(constants.EXCEPTION_END_MARKER);
 
   if (testFileEndMarkerIndex !== -1) {
-    // end marker
-    fileName = line.substring(0, testFileEndMarkerIndex);
-    return [ true, fileName, null ];
+    return new EndMarker();
   }
   else if (coverageEndMarker !== -1) {
-    // coverage result
     split = line.split(constants.DELIMITER);
     resultObj = {
       'coverage': split[1].replace(constants.COVERAGE_END_MARKER, '')
     };
-
-    return [ false, split[0], resultObj ];
+    return new CoverageMarker(runner, split[0], resultObj);
   }
   else if (exceptionIndex !== -1) {
     exceptionString = line.split(constants.DELIMITER);
-    exceptionObj = exceptionString[1].split(constants.EXCEPTION_END_MARKER);
-    return [exceptionString[0], exceptionObj[0], null];
+    exceptionJsons = exceptionString[1].split(constants.EXCEPTION_END_MARKER);
+    msg = sprintf("** EXCEPTION CAUGHT IN CHILD PROCESS **\n\n%s\n\n%s",
+                  exceptionString || 'No exception message assign to this error.',
+                  exceptionJsons[0]);
+    exception = new Error(msg);
+    return new ExceptionMarker(exception);
   }
   else {
-    // test result
     line = line.replace(constants.TEST_START_MARKER, '')
                .replace(constants.TEST_END_MARKER, '');
     split = line.split(constants.DELIMITER);
     resultObj = JSON.parse(split[1]);
-
-    return [ null, split[0], resultObj ];
+    return new TestResultMarker(runner, split[0], resultObj);
   }
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -163,13 +163,15 @@ LineProcessor.prototype._processData = function() {
 
 function parseResultLine(line) {
   // Returns a triple (end, fileName, resultObj)
-  var startMarkerIndex, endMarkerIndex, testFileEndMarkerIndex;
+  var startMarkerIndex, endMarkerIndex, testFileEndMarkerIndex, exceptionIndex;
   var coverageEndMarker, split, fileName, resultObj;
+  var exceptionString, exceptionObj;
 
   testFileEndMarkerIndex = line.indexOf(constants.TEST_FILE_END_MARKER);
   coverageEndMarker = line.indexOf(constants.COVERAGE_END_MARKER);
   startMarkerIndex = line.indexOf(constants.TEST_START_MARKER);
   endMarkerIndex = line.indexOf(constants.TEST_END_MARKER);
+  exceptionIndex = line.indexOf(constants.EXCEPTION_END_MARKER);
 
   if (testFileEndMarkerIndex !== -1) {
     // end marker
@@ -184,6 +186,11 @@ function parseResultLine(line) {
     };
 
     return [ false, split[0], resultObj ];
+  }
+  else if (exceptionIndex !== -1) {
+    exceptionString = line.split(constants.DELIMITER);
+    exceptionObj = exceptionString[1].split(constants.EXCEPTION_END_MARKER);
+    return [exceptionString[0], exceptionObj[0], null];
   }
   else {
     // test result

--- a/lib/util.js
+++ b/lib/util.js
@@ -233,9 +233,7 @@ function parseResultLine(line, runner) {
   }
   else if (coverageEndMarker !== -1) {
     split = line.split(constants.DELIMITER);
-    resultObj = {
-      'coverage': split[1].replace(constants.COVERAGE_END_MARKER, '')
-    };
+    resultObj = split[1].replace(constants.COVERAGE_END_MARKER, '');
     return new CoverageMarker(runner, split[0], resultObj);
   }
   else if (exceptionIndex !== -1) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -239,8 +239,8 @@ function parseResultLine(line, runner) {
   else if (exceptionIndex !== -1) {
     exceptionString = line.split(constants.DELIMITER);
     exceptionJsons = exceptionString[1].split(constants.EXCEPTION_END_MARKER);
-    msg = sprintf("** EXCEPTION CAUGHT IN CHILD PROCESS **\n\n%s\n\n%s",
-                  exceptionString || 'No exception message assign to this error.',
+    msg = sprintf('** EXCEPTION CAUGHT IN CHILD PROCESS **\n\n%s\n\n%s',
+                  exceptionString[0] || 'No exception message assign to this error.',
                   exceptionJsons[0]);
     exception = new Error(msg);
     return new ExceptionMarker(exception);

--- a/lib/util.js
+++ b/lib/util.js
@@ -169,7 +169,7 @@ function EndMarker() {
   this.throwPendingExceptions = function() {
     // does nothing; end of input has no exceptions to handle.
   };
-};
+}
 
 function ExceptionMarker(err) {
   this._err = err;
@@ -181,7 +181,7 @@ function ExceptionMarker(err) {
   this.throwPendingExceptions = function() {
     throw this._err;
   };
-};
+}
 
 function CoverageMarker(testRunner, filePath, coverage) {
   this._runner = testRunner;
@@ -195,7 +195,7 @@ function CoverageMarker(testRunner, filePath, coverage) {
   this.throwPendingExceptions = function() {
     // No exceptions exist for test results.
   };
-};
+}
 
 function TestResultMarker(testRunner, filePath, resultObj) {
   this._runner = testRunner;
@@ -209,7 +209,7 @@ function TestResultMarker(testRunner, filePath, resultObj) {
   this.throwPendingExceptions = function() {
     // No exceptions exist for test results.
   };
-};
+}
 
 function parseResultLine(line, runner) {
   // Returns one of {TestResultMarker, CoverageMarker,
@@ -220,7 +220,7 @@ function parseResultLine(line, runner) {
 
   var startMarkerIndex, endMarkerIndex, testFileEndMarkerIndex, exceptionIndex;
   var coverageEndMarker, split, fileName, resultObj;
-  var exceptionString, exceptionObj, exceptionJsons, msg;
+  var exception, exceptionString, exceptionObj, exceptionJsons, msg;
 
   testFileEndMarkerIndex = line.indexOf(constants.TEST_FILE_END_MARKER);
   coverageEndMarker = line.indexOf(constants.COVERAGE_END_MARKER);


### PR DESCRIPTION
This commit addresses https://github.com/cloudkick/whiskey/issues/57 .

PROBLEM

Too many times when working on Whiskey, I might make a seemingly
innocuous change to the program which causes timeouts to occur.  The
cause of the timeouts remain a total mystery.  The problem is the result
of a cascade of failures:

1) Something I changed causes an exception.
2) stdout/stderr is written to, and then the child Node process dies.
3) Meanwhile, the parent is unaware of this happening, and so sits on
its socket until it times out,
4) After the timeout, the parent process has no idea what killed the
child process, and so the only indication of a problem is that it's
listed in [TIMEOUT] status.

SOLUTION

Capture all exceptions that you can at the top-most level of the child
process, and marshal that data through the IPC channel back to the
parent process.

Then, alter the parent process to die immediately if an exception is
discovered.  Fail fast, fail often.

OTHER BENEFITS

Knowing what's causing some of the timeouts will, I _think_, be
beneficial from a Buildbot perspective as well.  No gaurantees, but it
_could_ be useful in uncovering some of the causes for intermittent
buildbot failures we've seen in the past.

HOW IT WORKS

It works by capturing all exceptions that leak to the main
run_test_file.js script, and forwards them to the _reportException
method on the current TestFile.  This stringifies the exception into a
record that is sent, via the usual Whiskey socket, to the parent Whiskey
runner process.

Once there, the lib/util.js parseResultLine method will decode this new
format and, if discovered to be an exception, will encapsulate it in a
triple, which can be uniquely identified as follows:

[true, filename, null] = File end without coverage data
[false, filenameIThink, coverageData] = File end with coverage data.
[null, testName, testResults] = Test invokation results
[string, string, null] = Exception report. (New as of this patch)

This is interpreted by the lib/run.js method
TestRunner._handleConnection(), which encapsulates the provided results
into a new exception to be handled by the parent process immediately.

The exception that is thrown is not an exact duplicate, but rather just
a simple object with a message field, formatted with text suitable for
human-readable display, as that appears to be Whiskey's default action
at this stage.  I'm not sure where the code resides that handles the
exception thrown in run.js.
