### PR TITLE
Upgrade istanbul

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -598,7 +598,7 @@ function run(cwd, argv) {
       }
 
       istanbulBinary = path.resolve(__dirname, '../node_modules/.bin/istanbul');
-      coverageArgs = [istanbulBinary, 'instrument', '--no-compact'];
+      coverageArgs = [istanbulBinary, 'instrument', '--no-compact', '--complete-copy'];
 
       if (options['coverage-exclude']) {
         coverageArgs.push(sprintf('-x %s', options['coverage-exclude']));

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "simplesets": "= 1.1.6",
     "logmagic": "= 0.1.4",
     "underscore": ">= 1.4.2",
-    "istanbul": ">= 0.1.36"
+    "istanbul": ">= 0.1.37"
   },
   "devDependencies": {
     "jshint": "2.1.3"


### PR DESCRIPTION
Upgrades to new version of `istanbul` which supports `--complete-copy` flag.

Now the whole integration part should behave the same way it did in the past when we used `jscoverage`.
