### PR TITLE
Simpler tap formatting

### DIFF
--- a/lib/reporters/test/tap.js
+++ b/lib/reporters/test/tap.js
@@ -127,7 +127,7 @@ TapReporter.prototype._reportResults = function() {
     startNum = 1;
   }
 
-  console.log('  %d..%d', startNum, testsLen);
+  console.log('%d..%d', startNum, testsLen);
 
   testNum = 0;
   for (i = 0; i < filesLen; i++) {
@@ -140,13 +140,13 @@ TapReporter.prototype._reportResults = function() {
         testResult = tests[test];
 
         if (testResult.status === 'success') {
-          console.log('  ok %d - %s: %s', testNum, testResult.file, testResult.name);
+          console.log('ok %d - %s: %s', testNum, testResult.file, testResult.name);
         }
         else if (testResult.status === 'failure') {
-          console.log('  not ok %d - %s: %s', testNum, testResult.file, testResult.name);
+          console.log('not ok %d - %s: %s', testNum, testResult.file, testResult.name);
         }
         else if (testResult.status === 'timeout') {
-          console.log('  not ok %d - %s: %s (timeout)', testNum, testResult.file,
+          console.log('not ok %d - %s: %s (timeout)', testNum, testResult.file,
                        testResult.name);
         }
       }


### PR DESCRIPTION
Most tap outputs (including node-tap) forgo any formatting such as leading spaces. I've run into one system that doesn't handle them well, so might be worth standardizing on no indentation.
