### PR TITLE
Deprecate nodejs <= 0.6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - "0.6"
   - "0.8"
   - "0.10"
   - "0.11"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jshint": "2.1.3"
   },
   "engines": {
-    "node": ">= 0.4.0"
+    "node": ">= 0.8.0"
   },
   "main": "./index",
   "bin": "./bin/whiskey",


### PR DESCRIPTION
Tests are failing in master on Node 0.6

I doubt many people in the Node.js community are running 0.6 anymore, so I think it's safe to deprecate Whiskey's support of it.
